### PR TITLE
Fix .T breaking whole-FOV image rendering

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: check-yaml
     -   id: detect-private-key
 -   repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "v2.27.0"
+    rev: "v2.28.1"
     hooks:
     -   id: pyproject-fmt
 -   repo: https://github.com/codespell-project/codespell
@@ -50,12 +50,12 @@ repos:
     hooks:
     -   id: actionlint
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.16.1"
+    rev: "v0.16.5"
     hooks:
     -   id: ruff-format
     -   id: ruff-check
 -   repo: https://github.com/software-gardening/almanack
-    rev: v0.1.16
+    rev: v0.1.17
     hooks:
     -   id: almanack-check
 -   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update

--- a/src/cytodataframe/frame.py
+++ b/src/cytodataframe/frame.py
@@ -5029,7 +5029,10 @@ class CytoDataFrame(pd.DataFrame):
             # Re-add bounding box columns if they are no longer available
             bounding_box_externally_joined = False
             if self._custom_attrs["data_bounding_box"] is not None and not all(
-                col in self.columns.tolist()
+                col
+                in (
+                    data if self._custom_attrs["is_transposed"] else self
+                ).columns.tolist()
                 for col in self._custom_attrs["data_bounding_box"].columns.tolist()
             ):
                 logger.debug("Re-adding bounding box columns.")
@@ -5049,15 +5052,18 @@ class CytoDataFrame(pd.DataFrame):
 
             # Re-add compartment center xy columns if they are no longer available
             compartment_center_externally_joined = False
+            use_data_for_compartment_center = (
+                self._custom_attrs["is_transposed"] or bounding_box_externally_joined
+            )
             if self._custom_attrs["compartment_center_xy"] is not None and not all(
                 col
-                in (data if bounding_box_externally_joined else self).columns.tolist()
+                in (data if use_data_for_compartment_center else self).columns.tolist()
                 for col in self._custom_attrs["compartment_center_xy"].columns.tolist()
             ):
                 logger.debug("Re-adding compartment center xy columns.")
                 data = (
                     data.join(other=self._custom_attrs["compartment_center_xy"])
-                    if bounding_box_externally_joined
+                    if use_data_for_compartment_center
                     else self.join(other=self._custom_attrs["compartment_center_xy"])
                 )
                 compartment_center_externally_joined = True
@@ -5072,11 +5078,13 @@ class CytoDataFrame(pd.DataFrame):
 
             # Re-add image path columns if they are no longer available
             image_paths_externally_joined = False
+            use_data_for_image_paths = (
+                self._custom_attrs["is_transposed"]
+                or compartment_center_externally_joined
+                or bounding_box_externally_joined
+            )
             if self._custom_attrs["data_image_paths"] is not None and not all(
-                col
-                in (
-                    data if compartment_center_externally_joined else self
-                ).columns.tolist()
+                col in (data if use_data_for_image_paths else self).columns.tolist()
                 for col in self._custom_attrs["data_image_paths"].columns.tolist()
             ):
                 logger.debug("Re-adding image path columns.")
@@ -5087,8 +5095,7 @@ class CytoDataFrame(pd.DataFrame):
                 )
                 data = (
                     data.join(other=self._custom_attrs["data_image_paths"])
-                    if compartment_center_externally_joined
-                    or bounding_box_externally_joined
+                    if use_data_for_image_paths
                     else self.join(other=self._custom_attrs["data_image_paths"])
                 )
                 image_paths_externally_joined = True

--- a/src/cytodataframe/frame.py
+++ b/src/cytodataframe/frame.py
@@ -5102,9 +5102,7 @@ class CytoDataFrame(pd.DataFrame):
             else:
                 data = (
                     data
-                    if self._custom_attrs["is_transposed"]
-                    or image_paths_externally_joined
-                    or bounding_box_externally_joined
+                    if use_data_for_image_paths or image_paths_externally_joined
                     else self.copy()
                 )
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1500,6 +1500,55 @@ def test_repr_html_render_whole_image_without_bounding_box_or_center(
     assert all(size == (expected_width, expected_height) for size in sizes)
 
 
+def test_repr_html_transposed_render_whole_image_without_bounding_box_or_center(
+    cytotable_NF1_data_parquet_shrunken: str,
+):
+    """
+    Tests that ``.T`` on a whole-FOV CytoDataFrame (no bounding box or
+    compartment center columns) still renders a transposed table with the
+    embedded image intact, rather than falling back to an untransposed table
+    of raw filenames.
+
+    See https://github.com/cytomining/CytoDataFrame/issues/226.
+    """
+
+    image_dir = (
+        f"{pathlib.Path(cytotable_NF1_data_parquet_shrunken).parent}/Plate_2_images"
+    )
+    image_filename = next(pathlib.Path(image_dir).glob("*.tif")).name
+
+    # a minimal whole-FOV frame with no bounding box or compartment
+    # center columns at all (mirrors the issue's reproduction).
+    df = pd.DataFrame(
+        {
+            "FileName_OrigDNA": [image_filename, image_filename],
+            "PathName_OrigDNA": [image_dir, image_dir],
+            "SomeMetric": [-2.5, -2.7],
+        }
+    )
+
+    whole_frame = CytoDataFrame(df, display_options={"render_whole_image": True})
+    assert whole_frame._custom_attrs["data_bounding_box"] is None
+    assert whole_frame._custom_attrs["compartment_center_xy"] is None
+
+    non_transposed_html = whole_frame.head(2)._repr_html_(debug=True)
+    transposed_html = whole_frame.head(2).T._repr_html_(debug=True)
+
+    non_transposed_images = re.findall(
+        r"data:image/png;base64,([^\"]+)", non_transposed_html
+    )
+    transposed_images = re.findall(r"data:image/png;base64,([^\"]+)", transposed_html)
+
+    # the transposed rendering must still embed the same images as the
+    # non-transposed rendering (previously it silently rendered none).
+    assert len(transposed_images) == len(non_transposed_images) > 0
+
+    # the transposed rendering must actually be transposed: the
+    # FileName_OrigDNA column becomes a row label instead of appearing
+    # in the header row.
+    assert ">FileName_OrigDNA<" in transposed_html
+
+
 def test_repr_html_offset_bounding_box_warns_when_centers_missing_with_bbox(
     cytotable_NF1_data_parquet_shrunken: str,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -3204,6 +3204,73 @@ def test_generate_jupyter_dataframe_html_with_joined_components(
     assert "<div>OME</div>" in html
 
 
+def test_generate_jupyter_dataframe_html_preserves_center_join_with_existing_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+):
+    """
+    Regression test: an externally joined compartment center must survive
+    rendering even when image-path columns are already present on the
+    frame (so the image-path re-add block takes its "already present"
+    branch instead of re-joining). Before the fix, that branch discarded
+    the joined compartment center columns, and the later ``.drop(...)``
+    of those columns raised a ``KeyError``.
+    """
+    base = pd.DataFrame(
+        {
+            "Image_FileName_DNA": ["dna.tiff"],
+            "Image_PathName_DNA": [str(tmp_path)],
+        },
+        index=[0],
+    )
+    cdf = CytoDataFrame(
+        base,
+        data_context_dir=str(tmp_path),
+        display_options={"render_whole_image": True},
+    )
+    assert cdf._custom_attrs["data_bounding_box"] is None
+    cdf._custom_attrs["compartment_center_xy"] = pd.DataFrame(
+        {"Cells_Location_Center_X": [5], "Cells_Location_Center_Y": [6]},
+        index=[0],
+    )
+    cdf._custom_attrs["data_image_paths"] = pd.DataFrame(
+        {"Image_PathName_DNA": [str(tmp_path)]},
+        index=[0],
+    )
+
+    options = {
+        "display.notebook_repr_html": True,
+        "display.max_rows": 10,
+        "display.min_rows": 10,
+        "display.max_columns": 10,
+        "display.show_dimensions": False,
+    }
+
+    monkeypatch.setattr("cytodataframe.frame.get_option", lambda name: options[name])
+    monkeypatch.setattr(
+        "cytodataframe.frame.CytoDataFrame.find_image_columns",
+        lambda self: ["Image_FileName_DNA"],
+    )
+    monkeypatch.setattr(
+        "cytodataframe.frame.CytoDataFrame.find_image_path_columns",
+        lambda self, image_cols, all_cols: {"Image_FileName_DNA": "Image_PathName_DNA"},
+    )
+    monkeypatch.setattr(
+        "cytodataframe.frame.CytoDataFrame.get_displayed_rows",
+        lambda self: [0],
+    )
+    monkeypatch.setattr(
+        cdf,
+        "process_image_data_as_html_display",
+        lambda **_kwargs: "<img src='x'/>",
+    )
+
+    # previously raised KeyError from dropping compartment center columns
+    # that had been silently discarded earlier in the method.
+    html = cdf._generate_jupyter_dataframe_html()
+    assert "<img src='x'/>" in html
+
+
 def test_render_output_displays_js_and_print_html(monkeypatch: pytest.MonkeyPatch):
     cdf = CytoDataFrame(pd.DataFrame({"A": [1]}))
     cdf._custom_attrs["_output"] = nullcontext()


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

.T joined image paths against the original frame, not the transposed copy. This fix joins against the correct copy in all three re-add steps and adds a regression test.

Fixes #226.

<!--
Thank you so much for your contribution to CytoDataFrame!

Please _succinctly_ summarize your proposed change.
Namely, consider addressing the following questions:

- What motivated you to open this pull request?
- Were there any special adjustments you had to make to complete the work?
- Are there any issues which are related to this pull request (you may used a `#<digit>` to reference GitHub issues as links within this description)?

Also, if you haven't already, please use `pre-commit run --all-files` to help check your files using this project's pre-commit configuration.
Pre-commit checks will automatically run as part of opening this pull request and we seek to ensure all checks pass before merging changes.
-->

## What kind of change(s) are included?

- [ ] Documentation (changes docs or other related content)
- [ ] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [ ] I have searched for existing content to ensure this is not a duplicate.
- [ ] I have performed a self-review of these additions (including spelling, grammar, and related).
- [ ] These changes pass all pre-commit checks.
- [ ] I have added comments to my code to help provide understanding
- [ ] I have added a test which covers the code changes found within this PR
- [ ] I have deleted all non-relevant text in this pull request template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTML rendering for transposed data views and views with previously joined metadata.
  - Preserved image rendering for transposed whole-image data without bounding-box or center columns.
  - Prevented missing, duplicated, or discarded image and compartment metadata during rendering.

- **Tests**
  - Added regression coverage for transposed whole-image HTML rendering and metadata preservation when image paths and compartment centers are combined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->